### PR TITLE
Fix session close handling in command-line client

### DIFF
--- a/pyebox/__main__.py
+++ b/pyebox/__main__.py
@@ -61,16 +61,13 @@ def main():
         loop.run_until_complete(task)
     except PyEboxError as exp:
         print(exp)
-        client.close_session()
         return
     if not client.get_data():
-        client.close_session()
         return
     if args.json:
         print(json.dumps(client.get_data()))
     else:
         _format_output(args.username, client.get_data())
-    client.close_session()
 
 
 if __name__ == '__main__':

--- a/pyebox/client.py
+++ b/pyebox/client.py
@@ -1,8 +1,6 @@
 """
 Pyebox
 """
-import asyncio
-import json
 import logging
 import re
 import async_timeout
@@ -38,7 +36,8 @@ class PyEboxError(Exception):
 
 class EboxClient(object):
 
-    def __init__(self, username, password, timeout=REQUESTS_TIMEOUT, session=None):
+    def __init__(self, username, password, timeout=REQUESTS_TIMEOUT,
+                 session=None):
         """Initialize the client object."""
         self.username = username
         self.password = password
@@ -184,14 +183,16 @@ class EboxClient(object):
         # Merge data
         self._data.update(home_data)
         self._data.update(usage_data)
+        # Close http session
+        await self.close_session()
 
     def get_data(self):
         """Return collected data"""
         return self._data
 
-    def close_session(self):
+    async def close_session(self):
         """Close current session."""
         if not self._session.closed:
             if self._session._connector_owner:
-                self._session._connector.close()
+                await self._session._connector.close()
             self._session._connector = None


### PR DESCRIPTION
While the master branch module is working well, using the command-line client still issues the warning:

> pyebox/client.py:197: RuntimeWarning: coroutine 'noop2' was never awaited
>   self._session._connector.close()

This PR aims to fix this by removing session-closing duties from the client and handing them over to the EboxClient class.

**BREAKING CHANGE:** method `close_session()` must now be awaited.